### PR TITLE
Fix: infinite loop when calling ForRequestToken

### DIFF
--- a/src/OAuth/OAuthRequest.cs
+++ b/src/OAuth/OAuthRequest.cs
@@ -272,7 +272,7 @@ namespace OAuth
 
         public static OAuthRequest ForRequestToken(string consumerKey, string consumerSecret, string callbackUrl, OAuthSignatureMethod oAuthSignatureMethod = OAuthSignatureMethod.HmacSha1)
         {
-            var credentials = ForRequestToken(consumerKey, consumerSecret, null, oAuthSignatureMethod: oAuthSignatureMethod);
+            var credentials = ForRequestToken(consumerKey, consumerSecret, oAuthSignatureMethod: oAuthSignatureMethod);
             credentials.CallbackUrl = callbackUrl;
             return credentials;
         }


### PR DESCRIPTION
ForRequestToken is calling itself. It should call the other method with a different signature.